### PR TITLE
Allow dots in topic name and filter regexes.

### DIFF
--- a/aio_mqtt/client.py
+++ b/aio_mqtt/client.py
@@ -17,6 +17,7 @@ import collections
 import datetime
 import enum
 import struct
+import sys
 import time
 import typing as ty
 import uuid
@@ -162,8 +163,12 @@ class Client:
         self._outgoing_messages: ty.Dict[int, InflightMessage[PublishableMessage]] = {}
         self._reader: ty.Optional[aio.StreamReader] = None
         self._writer: ty.Optional[aio.StreamWriter] = None
-        self._drain_lock = aio.Lock(loop=self._loop)
-        self._connection_lock = aio.Lock(loop=self._loop)
+        self._drain_lock = aio.Lock(
+            **({"loop": loop} if sys.version_info[:2] < (3, 8) else {})
+        )
+        self._connection_lock = aio.Lock(
+            **({"loop": loop} if sys.version_info[:2] < (3, 8) else {})
+        )
         self._ping_response_received = False
         self._consumer_queues: TopicMatcher[ty.Set[aio.Queue[DeliveredMessage]]] = TopicMatcher()
         self._disconnect_reason: ty.Optional[aio.Future] = None

--- a/aio_mqtt/constants.py
+++ b/aio_mqtt/constants.py
@@ -45,5 +45,5 @@ MAXIMUM_PAYLOAD_SIZE: int = 268435455
 MAXIMUM_TOPIC_LENGTH: int = 65535
 MAXIMUM_PACKET_ID: int = 65536
 
-TOPIC_FILTER_REGEX = re.compile(r'^/?(\+|[\w-]+)(/(\+|[\w-]+))*(/#)?$')
-TOPIC_NAME_REGEX = re.compile(r'^/?[\w-]+(/[\w-]+)*$')
+TOPIC_FILTER_REGEX = re.compile(r'^/?(\+|[\w\.-]+)(/(\+|[\w\.-]+))*(/#)?$')
+TOPIC_NAME_REGEX = re.compile(r'^/?[\w\.-]+(/[\w\.-]+)*$')


### PR DESCRIPTION
Allow dots in topic name and filter regexes.
Necessary for sparkplug b to work
https://projects.eclipse.org/projects/iot.tahu